### PR TITLE
Color change when hovering over hamburger menu

### DIFF
--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -198,7 +198,7 @@
 				transform: rotate(0deg);
 				border-radius:50%;
 				padding:10px;
-				transition: .5s ease-in-out;
+				transition: .25s ease-in-out;
 				cursor: pointer;
 				background-color:$quantum_burst;
 				z-index: 200;
@@ -251,6 +251,9 @@
 				&.open + ul {
 					right:0;
 				}
+			}
+			#nav-icon:hover {
+				background-color: $quantum_hover!important;
 			}
 		}
 		


### PR DESCRIPTION
Added shading on hover for the floating action button (hamburger menu toggle).
This makes the floating action button consistent with other pink buttons on the website.

Quick demo after applying these changes in the inspector:
![2018-04-05_00-28-13](https://user-images.githubusercontent.com/28553263/38341476-c5dee328-3846-11e8-9bd2-1818ae837899.gif)

_Let me know if you have any questions._