### PR TITLE
Smaller shadow for the hamburger menu

### DIFF
--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -202,8 +202,11 @@
 				cursor: pointer;
 				background-color:$quantum_burst;
 				z-index: 200;
-				box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.16), 4px 8px 8px 0 rgba(0, 0, 0, 0.32);
+				box-shadow: $shadow;
 
+				&:hover {
+					background-color: $quantum_hover!important;
+				}
 				span:nth-child(1) {
 					top: 20px;
 				}
@@ -251,9 +254,6 @@
 				&.open + ul {
 					right:0;
 				}
-			}
-			#nav-icon:hover {
-				background-color: $quantum_hover!important;
 			}
 		}
 		


### PR DESCRIPTION
Changed the box-shadow to $shadow based on the received feedback. Also slightly cleaned up the hover code.

_Feel free to reject this PR if the QRL team decides to go without shadows on the hamburger menu button._