### PR TITLE
Add max-age for CloudFront's Edge cache

### DIFF
--- a/s3_website.yml
+++ b/s3_website.yml
@@ -1,3 +1,4 @@
 s3_id: <%= ENV['S3_ACCESS_KEY_ID'] %>
 s3_secret: <%= ENV['S3_SECRET_KEY'] %>
 s3_bucket: theqrl.org
+cache_control: public, no-transform, max-age=3600, s-maxage=3600


### PR DESCRIPTION
CloudFront Edge cache likes to hang onto things for 24 hours, max-age reduces this to 1 hour, which is sufficient for web distributions.