### PR TITLE
Change "Comments" to "Comment on GitHub"

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -121,7 +121,7 @@ permalink: /protocol-updates/
           <div class="more">
             {% if qip.comments-uri %}
             <a class="cta" href="{{ qip.comments-uri }}">
-              Comments {% if qip.comments-count %}
+              Comment on GitHub {% if qip.comments-count %}
                 ({{ qip.comments-count }})
               {% endif %}
             </a> 


### PR DESCRIPTION
Currently, the "Comments (X)" button sits right next to the "Read More" button. They are the same color, size, and font. Yet the "Comments (X)" button directs users outside our domain, to GitHub, whereas the "Read More" button does not. I think that by changing "Comments" to "Comment on GitHub" we will alert users they are about to leave the website.