### PR TITLE
Remove "Where we were"

### DIFF
--- a/index.html
+++ b/index.html
@@ -345,7 +345,7 @@ layout: default
 
 
    <div class="header-section">
-      <h2>Where we were</h2>
+      
       <h3>Conferences we attended</h3>
     </div>
     {% assign now = site.time | date: '%s' | plus:0 %}


### PR DESCRIPTION
Remove "Where we were" as it is redundant when "Conferences we attended" is directly below it