### PR TITLE
make whitepaper pdf visualizable via Google docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ layout: default
         <h1>The Quantum Resistant Ledger</h1>
         <h2>Secure digital assets for longevity</h2>
         <p>Externally audited enterprise-grade blockchain platform secure against an attack from quantum computers.</p>
-        <p><a href="/research/">Citations & Research</a>, <a href="https://github.com/theQRL/Whitepaper/blob/master/QRL_whitepaper.pdf">Whitepaper &raquo;</a></p>
+        <p><a href="/research/">Citations & Research</a>, <a href="https://docs.google.com/viewer?url=https://github.com/theQRL/Whitepaper/raw/master/QRL_whitepaper.pdf">Whitepaper &raquo;</a></p>
       </div>
     </div>
     <div class="grid">


### PR DESCRIPTION
because the github link did not directly open or download the pdf. See https://webapps.stackexchange.com/questions/48061/can-i-trick-github-into-displaying-the-pdf-in-the-browser-instead-of-downloading.
Thanks Jackalyst