### PR TITLE
Fix page title crop on single-article and blog pages

### DIFF
--- a/assets/sass/pages/_blog-inner.scss
+++ b/assets/sass/pages/_blog-inner.scss
@@ -92,6 +92,7 @@
         }
         a{
             text-decoration: underline;
+            overflow-wrap: anywhere;
             transition: $time-3;
             &:hover{
                 color: $color-yellow;

--- a/assets/sass/pages/_blog-inner.scss
+++ b/assets/sass/pages/_blog-inner.scss
@@ -27,7 +27,7 @@
                 line-height: 41px;
                 margin-bottom: 27px;
             }
-            @include mobile{
+            @include mobile {
                 font-size: 28px;
                 line-height: 36px;
                 margin-bottom: 34px;
@@ -92,7 +92,9 @@
         }
         a{
             text-decoration: underline;
-            overflow-wrap: anywhere;
+            display: inline-block;
+            word-break: break-all;
+
             transition: $time-3;
             &:hover{
                 color: $color-yellow;


### PR DESCRIPTION
Caused by excessively long links.