### PR TITLE
New feat: Add under maintenance status indicator to market

### DIFF
--- a/assets/sass/_overrides.scss
+++ b/assets/sass/_overrides.scss
@@ -83,6 +83,51 @@
       padding: 40px;
       background-color:#FCFCFC;
   }
+  .grid-markets {
+    .core__el {
+      position:relative;
+    }
+    .core__el__top {
+      display:none;
+      text-align:center;
+      background-color: $color-alert-yellow-bg; margin-bottom:-40px;
+      padding: 0 26px;
+      line-height: 40px;
+      flex: 1;
+      transition: .5s ease-in-out;
+      left:0; top:0; right:0;
+      transition-property: color,background-color;
+      z-index: 2;
+      color: $color-alert-yellow-fg;
+      font-size: 19px;
+      font-family: "Source Sans Pro Bold",sans-serif;
+      cursor: default;
+    }
+    .maintenance {
+      &:hover {
+        .core__el__img,
+        .core__el__inner {
+          filter:grayscale(0);
+        }
+      }
+      
+      .core__el__top {
+        
+        display:block;
+      }
+      .core__el__img, 
+      .core__el__inner {
+        filter: grayscale(0.8);
+        transition: 1s all;
+      }
+      .core__el__img {
+        img {
+          position:relative;
+          top: 20px;
+        }
+      }
+    }
+  }
   
   .grid-markets span.market {
     background-color: #4AAFFF;

--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -30,6 +30,8 @@ $color-black: #0a1720;
 $color-yellow: #FFA729;
 $color-blue: #4AAFFF;
 
+$color-alert-yellow-bg: #fadda2;
+$color-alert-yellow-fg: #966e00; 
 
 // timing
 $time-3: 300ms ease-in-out;

--- a/data/markets.yml
+++ b/data/markets.yml
@@ -13,6 +13,7 @@
   link: https://international.bittrex.com/Market/Index?MarketName=BTC-QRL
   logo: bittrex-global.svg
   type: Centralized Exchange
+  maintenance: true
 
 - name: Biteeu
   markets: 

--- a/layouts/shortcodes/markets.html
+++ b/layouts/shortcodes/markets.html
@@ -24,7 +24,8 @@
 {{ if or (eq $output "grid") }}<div id="markets" class="grid grid-markets grid-three-cols">{{ end }}
 	{{ range $.Site.Data.markets }}
 		<a href="{{ .link }}" class="no-ul">
-          <div class="core__el animate-fade" style="opacity: 1; visibility: inherit;">
+          <div class="core__el animate-fade{{ if .maintenance }} maintenance{{ end }}" style="opacity: 1; visibility: inherit;">
+			<div class="core__el__top">Under Maintenance</div>
             <div class="core__el__img">
               <img src="/img/markets/{{ .logo }}" alt="{{ .name }}">
             </div>


### PR DESCRIPTION
With the markets page being one of the most requested pages, and with it being a point where people are frequently sent while being on-boarded, it's important to ensure a good (often first-time) user experience.

Unfortunately, the experience of heading to a market from the markets page that's unavailable (either no market, or inaccessible due to withdrawal/deposit maintenance) would be negative, and could lead to a user abandoning the process all-together.

This feature gives quick indicator so the user can know what markets are currently undergoing maintenance. Based on the indicated information, the user can avoid the market, and head to one that's available, thus decreasing frustration and helping ensure the desired result is achieved. 

When the market becomes available again, the status is removed through a one line content change.