### PR TITLE
Remove CoinTiger from markets page

### DIFF
--- a/data/markets.yml
+++ b/data/markets.yml
@@ -6,15 +6,6 @@
   logo: mexc.svg
   type: Centralized Exchange
 
-- name: Cointiger
-  markets: 
-    - market: BTC-QRL
-      link: https://www.cointiger.com/en-us/#/trade_center?coin=qrl_btc
-  link: https://www.cointiger.com/en-us/#/trade_center?coin=qrl_btc
-  logo: cointiger.png
-  maintenance: true
-  type: Centralized Exchange
-
 - name: "Dex-Trade"
   markets:
     - market: QRL-USDT


### PR DESCRIPTION
The decision to remove CoinTiger from our markets page stems from various factors.

First, CMC has flagged CoinTiger, indicating a potential concern. Additionally, CoinGecko has already taken the step of removing CoinTiger from their platform. Furthermore, we've received multiple reports from users experiencing difficulties in withdrawing their funds from CoinTiger.

In light of these developments and to ensure the safety and reliability of our markets page, we have opted to remove CoinTiger.

As a reminder, QRL exercises little influence over exchanges. It's also crucial to emphasise the importance of maintaining self-custody of your blockchain assets.